### PR TITLE
错误修复

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,12 +11,12 @@ archives_base_name = eventtweaker
 
 # Boilerplate Options
 use_mixins = true
-use_coremod = true
+use_coremod = false
 use_assetmover = false
 
 # Access Transformer files should be in the root of `resources` folder and with the filename formatted as: `{archives_base_name}_at.cfg`
 use_access_transformer = false
 
 # Coremod Arguments
-include_mod = true
-coremod_plugin_class_name = com.wdcftgg.eventtweaker.mixins.MixinConfig
+include_mod = false
+coremod_plugin_class_name =

--- a/src/main/java/com/wdcftgg/eventtweaker/common/api/expand/ExpandArray.java
+++ b/src/main/java/com/wdcftgg/eventtweaker/common/api/expand/ExpandArray.java
@@ -15,10 +15,10 @@ import java.util.List;
 public class ExpandArray {
 
     @ZenMethod
-    public <T> T[] add(T[] array, T any) {
-        List<T> list = Arrays.asList(array);
+    public static <T> T[] add(T[] array, T any) {
+        List<T> list = new ArrayList<>(Arrays.asList(array));
         list.add(any);
-        array = list.toArray(array);
-        return array;
+        return list.toArray(Arrays.copyOf(array, list.size()));
     }
 }
+

--- a/src/main/java/com/wdcftgg/eventtweaker/mixins/MixinConfig.java
+++ b/src/main/java/com/wdcftgg/eventtweaker/mixins/MixinConfig.java
@@ -1,8 +1,5 @@
 package com.wdcftgg.eventtweaker.mixins;
 
-import com.wdcftgg.eventtweaker.EventTweaker;
-import net.minecraftforge.common.ForgeVersion;
-import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import zone.rong.mixinbooter.ILateMixinLoader;
 
 import java.util.Collections;
@@ -15,8 +12,6 @@ import java.util.List;
  * @create 2024/1/20 10:54
  */
 @SuppressWarnings("unused")
-@IFMLLoadingPlugin.Name(EventTweaker.MODID)
-@IFMLLoadingPlugin.MCVersion(ForgeVersion.mcVersion)
 public class MixinConfig implements ILateMixinLoader {
     @Override
     public List<String> getMixinConfigs() {


### PR DESCRIPTION
修复mixin不生效问题
修复一个方法报错的问题
不要随便改名了，eventtweaker1.5版本因为路径错误导致部分方法失效了